### PR TITLE
Persist player joins to Firestore

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { addWeeks, format } from 'date-fns';
 import { nl } from 'date-fns/locale';
+import { doc, setDoc, deleteDoc } from 'firebase/firestore';
+import { db, ensureAuth } from '@/lib/firebase';
 
 /* =========================
    Types
@@ -826,7 +828,7 @@ export default function Page() {
   /* =========================
      Self-join / leave (spelers)
   ========================= */
-  const joinCourt = (date: string, timeSlot: string, court: number) => {
+  const joinCourt = async (date: string, timeSlot: string, court: number) => {
     if (!session) return alert('Log in om deel te nemen.');
     const availableSet = new Set(playersAvailableFor(date, timeSlot));
     if (!availableSet.has(myName!)) {
@@ -843,6 +845,8 @@ export default function Page() {
     const mt = getMatchType(date, timeSlot, court);
     const cat = getCategory(date, timeSlot, court);
     const needed = mt === 'single' ? 2 : 4;
+
+    const docId = `${date}_${timeSlot}_${court}`;
 
     if (!existing) {
       const arr = Array.from({ length: needed }, () => '');
@@ -864,6 +868,8 @@ export default function Page() {
         } as Reservation),
       };
       setReservations((prev) => [...prev, fresh]);
+      await ensureAuth();
+      await setDoc(doc(db, 'reservations', docId), fresh, { merge: true });
       if (fresh.notifiedFull) sendMatchFullMessages(fresh);
       return;
     }
@@ -898,6 +904,20 @@ export default function Page() {
       })
     );
 
+    await ensureAuth();
+    await setDoc(
+      doc(db, 'reservations', docId),
+      {
+        ...existing,
+        players: newPlayers,
+        notifiedFull: existing.notifiedFull || willBeFull,
+        matchType: mt,
+        category: cat,
+        ...(willBeFull ? {} : { result: null }),
+      },
+      { merge: true }
+    );
+
     // Stuur meldingen één keer, zonder extra setTimeout
     if (!existing.notifiedFull && willBeFull) {
       const fullRes: Reservation = {
@@ -911,8 +931,9 @@ export default function Page() {
     }
   };
 
-  const leaveCourt = (res: Reservation, who: string) => {
+  const leaveCourt = async (res: Reservation, who: string) => {
     if (!isAdmin && who !== myName) return;
+    let newPlayers: string[] | null = null;
     setReservations((prev) =>
       prev.map((r) => {
         if (r !== res) return r;
@@ -924,12 +945,25 @@ export default function Page() {
         copy.notifiedFull = false;
         // Resultaat ongeldig maken als teams/players wijzigen
         delete copy.result;
+        newPlayers = copy.players;
         return copy;
       })
     );
+    if (!newPlayers) return;
+    await ensureAuth();
+    const docId = `${res.date}_${res.timeSlot}_${res.court}`;
+    await setDoc(
+      doc(db, 'reservations', docId),
+      { ...res, players: newPlayers, notifiedFull: false, result: null },
+      { merge: true }
+    );
   };
 
-  const removeReservation = (date: string, timeSlot: string, court: number) => {
+  const removeReservation = async (
+    date: string,
+    timeSlot: string,
+    court: number
+  ) => {
     const res = findReservation(date, timeSlot, court);
     if (!res) return;
     if (!canModifyReservation(res))
@@ -944,6 +978,9 @@ export default function Page() {
           !(r.date === date && r.timeSlot === timeSlot && r.court === court)
       )
     );
+    await ensureAuth();
+    const docId = `${date}_${timeSlot}_${court}`;
+    await deleteDoc(doc(db, 'reservations', docId));
   };
 
   /* =========================


### PR DESCRIPTION
## Summary
- store new or updated reservations in Firestore when players join a court
- update or clear reservations in Firestore when players leave or remove matches

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a62206b9bc8327a2ca00e28ae9efff